### PR TITLE
No need for "node" in bin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "ncatestify-cypressio",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
+      "bin": {
+        "ncatestify": "node ./cypress/scripts/run.js"
+      },
       "devDependencies": {
         "cypress": "^9.6.1",
         "typescript": "^4.6.4"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "install": "npm link"
   },
   "bin":{
-    "ncatestify": "node ./cypress/scripts/run.js"
+    "ncatestify": "./cypress/scripts/run.js"
   },
   "keywords": [
     "Cypress.IO",


### PR DESCRIPTION
There is no need to explicitly call "node" and the js-file in the "package.json". This could solve the problem while installing the package.